### PR TITLE
Handle sync failures by restoring user state

### DIFF
--- a/src/main/java/cat/politecnicllevant/core/service/UsuariService.java
+++ b/src/main/java/cat/politecnicllevant/core/service/UsuariService.java
@@ -13,6 +13,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.text.Normalizer;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 @Service
@@ -335,6 +336,20 @@ public class UsuariService {
         List<Usuari> usuaris = usuariRepository.findAll();
         for (Usuari usuari : usuaris) {
             usuari.setActiu(false);
+            usuariRepository.save(usuari);
+        }
+    }
+
+    @Transactional
+    public void restaurarEstatActiu(Map<Long, Boolean> estatActiuOriginal) {
+        if (estatActiuOriginal == null || estatActiuOriginal.isEmpty()) {
+            return;
+        }
+
+        List<Usuari> usuaris = usuariRepository.findAllById(estatActiuOriginal.keySet());
+        for (Usuari usuari : usuaris) {
+            Boolean actiu = estatActiuOriginal.get(usuari.getIdusuari());
+            usuari.setActiu(actiu);
             usuariRepository.save(usuari);
         }
     }


### PR DESCRIPTION
## Summary
- capture the original active state of users before launching the synchronization
- wrap the sync workflow with error handling that restores user activity flags if something fails
- add a service helper to reapply the saved activity status and ensure the centre flag is reset

## Testing
- `./mvnw -q -DskipTests package` *(fails: Maven wrapper is not present in the repository)*

------
https://chatgpt.com/codex/tasks/task_b_68ee181b8558832f870943ed406c3ec7