### PR TITLE
Prevent sync failures from leaving users inactive

### DIFF
--- a/src/main/java/cat/politecnicllevant/core/service/UsuariService.java
+++ b/src/main/java/cat/politecnicllevant/core/service/UsuariService.java
@@ -338,6 +338,24 @@ public class UsuariService {
             usuariRepository.save(usuari);
         }
     }
+
+    @Transactional
+    public void restaurarActius(List<UsuariDto> usuarisOriginals) {
+        if (usuarisOriginals == null) {
+            return;
+        }
+
+        for (UsuariDto usuariOriginal : usuarisOriginals) {
+            if (usuariOriginal == null || usuariOriginal.getIdusuari() == null) {
+                continue;
+            }
+
+            usuariRepository.findById(usuariOriginal.getIdusuari()).ifPresent(usuari -> {
+                usuari.setActiu(usuariOriginal.getActiu());
+                usuariRepository.save(usuari);
+            });
+        }
+    }
     @Transactional
     public void suspendreUsuari(UsuariDto usuari) {
         usuari.setGsuiteSuspes(true);


### PR DESCRIPTION
## Summary
- snapshot the pre-synchronisation user state and restore it whenever the process fails
- ensure the synchronisation flag on the centre is always cleared even when an exception occurs
- add a service helper to reinstate the previous `actiu` flags for users

## Testing
- mvn -q -DskipTests compile *(fails: missing dependency `cat.politecnicllevant:common:0.0.1-SNAPSHOT`)*

------
https://chatgpt.com/codex/tasks/task_b_68ee181b8558832f870943ed406c3ec7